### PR TITLE
Dev/link posts in data

### DIFF
--- a/_data/read/2022.yml
+++ b/_data/read/2022.yml
@@ -1,3 +1,5 @@
+- title: Espresso Lessons
+  post: '/2022/04/23/Espresso-Lessons.html'
 - title: The Linux Programming Interface
   author: Michael Kerrisk
   post: '/2022/03/29/unix-programming-interface.html'
@@ -6,3 +8,4 @@
 - title: Cracking the Coding Interview
 - title: A Clash of Kings
 - title: Enjoy the Ride
+  post: '/2022/04/03/Enjoy-the-Ride.html'

--- a/_data/read/2022.yml
+++ b/_data/read/2022.yml
@@ -1,5 +1,8 @@
-- Automate the Boring Stuff
-- A Game of Thrones
-- Cracking the Coding Interview
-- A Clash of Kings
-- Enjoy the Ride
+- title: The Linux Programming Interface
+  author: Michael Kerrisk
+  post: '/2022/03/29/unix-programming-interface.html'
+- title: Automate the Boring Stuff
+- title: A Game of Thrones
+- title: Cracking the Coding Interview
+- title: A Clash of Kings
+- title: Enjoy the Ride

--- a/pages/books.md
+++ b/pages/books.md
@@ -21,6 +21,7 @@ layout: page
 {% endfor %}
 
 ## 2022
+<<<<<<< HEAD
   - [The Linux Programming Interface](/2022/03/29/unix-programming-interface.html)
   - [Espresso Lessons](/2022/04/23/Espresso-Lessons.html
 ){% for book in site.data.read.2022 %}
@@ -28,6 +29,10 @@ layout: page
 - [The Linux Programming Interface](/2022/03/29/unix-programming-interface.html)
 {% for book in site.data.read.2022 %}
 - {{ book }}
+=======
+{% for book in site.data.read.2022%}
+- [{{book.title}}]({{ book.post}}): {{ book.author }}
+>>>>>>> 1d2419b7 (use data structures for linking posts)
 {% endfor %}
 
 ## 2021

--- a/pages/books.md
+++ b/pages/books.md
@@ -25,24 +25,27 @@ layout: page
   - [Espresso Lessons](/2022/04/23/Espresso-Lessons.html
 ){% for book in site.data.read.2022 %}
   - {{ book }}
+- [The Linux Programming Interface](/2022/03/29/unix-programming-interface.html)
+{% for book in site.data.read.2022 %}
+- {{ book }}
 {% endfor %}
 
 ## 2021
 {% for book in site.data.read.2021 %}
-  - {{ book }}
+- {{ book }}
 {% endfor %}
 
 ## 2020
 {% for book in site.data.read.2020 %}
-  - {{ book }}
+- {{ book }}
 {% endfor %}
 
 ## 2019
 {% for book in site.data.read.2019 %}
-  - {{ book }}
+- {{ book }}
 {% endfor %}
 
 ## 2018
 {% for book in site.data.read.2018 %}
-  - {{ book }}
+- {{ book }}
 {% endfor %}

--- a/pages/books.md
+++ b/pages/books.md
@@ -21,18 +21,8 @@ layout: page
 {% endfor %}
 
 ## 2022
-<<<<<<< HEAD
-  - [The Linux Programming Interface](/2022/03/29/unix-programming-interface.html)
-  - [Espresso Lessons](/2022/04/23/Espresso-Lessons.html
-){% for book in site.data.read.2022 %}
-  - {{ book }}
-- [The Linux Programming Interface](/2022/03/29/unix-programming-interface.html)
-{% for book in site.data.read.2022 %}
-- {{ book }}
-=======
 {% for book in site.data.read.2022%}
 - [{{book.title}}]({{ book.post}}): {{ book.author }}
->>>>>>> 1d2419b7 (use data structures for linking posts)
 {% endfor %}
 
 ## 2021


### PR DESCRIPTION
# Summary
Use `data` to support linking to post versus placing directly in `page`